### PR TITLE
fix #281

### DIFF
--- a/Source/EasyNetQ.Tests/EventBusTests.cs
+++ b/Source/EasyNetQ.Tests/EventBusTests.cs
@@ -1,6 +1,5 @@
 ﻿// ReSharper disable InconsistentNaming
 
-using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 

--- a/Source/EasyNetQ/IEventBus.cs
+++ b/Source/EasyNetQ/IEventBus.cs
@@ -15,42 +15,68 @@ namespace EasyNetQ
 
     public class EventBus : IEventBus
     {
-        private readonly ConcurrentDictionary<Type, IList<object>> subscriptions =
-            new ConcurrentDictionary<Type, IList<object>>();
+        private class Handlers
+        {
+            private readonly object internalHandlersLock = new object();
+            private readonly List<object> internalHandlers = new List<object>(); 
+
+            public void Add(object handler)
+            {
+                lock (internalHandlersLock)
+                    internalHandlers.Add(handler);
+            }
+
+            public void Remove(object handler)
+            {
+                lock (internalHandlersLock)
+                    internalHandlers.Remove(handler);
+            }
+
+            public IEnumerable<object> AsEnumerable()
+            {
+                lock (internalHandlersLock)
+                    return internalHandlers.ToArray();
+            }
+        }
+
+        private readonly ConcurrentDictionary<Type, Handlers> subscriptions = new ConcurrentDictionary<Type, Handlers>();
+        private readonly object subscriptionLock = new object();
 
         public void Publish<TEvent>(TEvent @event)
         {
-            if (!subscriptions.ContainsKey(typeof(TEvent))) return;
-
-            // Create a local copy of handlers to avoid any interference from
-            // handler subscribing to events and modifying collection.
-            var handlers = new List<object>(subscriptions[typeof(TEvent)]);
-            foreach (var eventHandler in handlers)
-            {
-                ((Action<TEvent>)eventHandler)(@event);
-            }
+            Handlers handlers;
+            if (!subscriptions.TryGetValue(typeof (TEvent), out handlers))
+                return;
+            foreach (var handler in handlers.AsEnumerable())
+                ((Action<TEvent>) handler)(@event);
         }
 
         public CancelSubscription Subscribe<TEvent>(Action<TEvent> eventHandler)
         {
-            CancelSubscription cancelSubscription = null;
+            AddSubscription(eventHandler);
+            return GetCancelSubscriptionDelegate(eventHandler);
+        }
 
-            subscriptions.AddOrUpdate(typeof(TEvent),
-                    t =>
-                    {
-                        var l = new List<object> { eventHandler };
-                        cancelSubscription = () => l.Remove(eventHandler);
-                        return l;
-                    },
-                    (t, l) =>
-                    {
-                        l.Add(eventHandler);
-                        cancelSubscription = () => l.Remove(eventHandler);
-                        return l;
-                    }
-                );
+        private void AddSubscription<TEvent>(Action<TEvent> handler)
+        {
+            var type = typeof (TEvent);
+            Handlers handlers;
+            if (!subscriptions.TryGetValue(type, out handlers))
+                lock (subscriptionLock)
+                    if (!subscriptions.TryGetValue(type, out handlers))
+                        subscriptions[type] = handlers = new Handlers();
+            handlers.Add(handler);
+        }
 
-            return cancelSubscription;
+        private CancelSubscription GetCancelSubscriptionDelegate<TEvent>(Action<TEvent> eventHandler)
+        {
+            return () =>
+                {
+                    Handlers handlers;
+                    if (!subscriptions.TryGetValue(typeof (TEvent), out handlers))
+                        return;
+                    handlers.Remove(eventHandler);
+                };
         }
     }
 

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,10 +2,11 @@
 using System.Reflection;
 
 // EasyNetQ version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.39.4.0")]
+[assembly: AssemblyVersion("0.39.5.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
+// 0.39.5.0 Fix concurrent bugs in EventBus
 // 0.39.4.0 ConsumerDispatcher's dispatching thread shall not die due to single action failure.
 // 0.39.3.0 SendAsync should return Task
 // 0.39.2.0 Removed Immutable Packages and replaced IEventBus.cs with previous version to prevent cs1685 compiler warnings


### PR DESCRIPTION
Hi Mike!

I hope it fixes #281 :smile:

A couple words about it:
1. Handlers. Unfortunatly, ConcurrentBag is not usable because it's unordered. So, here is just simple implementation. AsEnumerable - provide copy for enumeration.
2. AddSubscription works with double check-locking


